### PR TITLE
Feat/replace spring event with rabbitmq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -404,6 +404,12 @@
             <artifactId>guava</artifactId>
             <version>33.0.0-jre</version>
         </dependency>
+
+        <!-- RabbitMQ 消息队列 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/rymcu/forest/auth/BaseHashedCredentialsMatcher.java
+++ b/src/main/java/com/rymcu/forest/auth/BaseHashedCredentialsMatcher.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.auth;
 
 import com.rymcu.forest.util.UserUtils;

--- a/src/main/java/com/rymcu/forest/auth/JwtConstants.java
+++ b/src/main/java/com/rymcu/forest/auth/JwtConstants.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.auth;
 
 /**

--- a/src/main/java/com/rymcu/forest/auth/JwtFilter.java
+++ b/src/main/java/com/rymcu/forest/auth/JwtFilter.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.auth;
 
 import com.alibaba.fastjson2.JSONObject;

--- a/src/main/java/com/rymcu/forest/auth/JwtRealm.java
+++ b/src/main/java/com/rymcu/forest/auth/JwtRealm.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.auth;
 
 import com.rymcu.forest.dto.TokenUser;

--- a/src/main/java/com/rymcu/forest/auth/RedisTokenManager.java
+++ b/src/main/java/com/rymcu/forest/auth/RedisTokenManager.java
@@ -6,7 +6,8 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationEventPublisher;
+import com.rymcu.forest.config.RabbitMQConfig;
+import com.rymcu.forest.event.EventPublisher;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -27,7 +28,7 @@ public class RedisTokenManager implements TokenManager {
     @Autowired
     private StringRedisTemplate redisTemplate;
     @Resource
-    private ApplicationEventPublisher applicationEventPublisher;
+    private EventPublisher eventPublisher;
 
     /**
      * 生成TOKEN
@@ -60,7 +61,7 @@ public class RedisTokenManager implements TokenManager {
         String result = redisTemplate.boundValueOps(key.toString()).get();
         if (StringUtils.isBlank(result)) {
             // 更新最后在线时间
-            applicationEventPublisher.publishEvent(new AccountEvent(model.getUsername()));
+            eventPublisher.publish(RabbitMQConfig.RK_ACCOUNT_LOGIN, new AccountEvent(model.getUsername()));
             redisTemplate.boundValueOps(key.toString()).set(LocalDateTime.now().toString(), JwtConstants.LAST_ONLINE_EXPIRES_MINUTE, TimeUnit.MINUTES);
         }
         return true;

--- a/src/main/java/com/rymcu/forest/auth/RedisTokenManager.java
+++ b/src/main/java/com/rymcu/forest/auth/RedisTokenManager.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.auth;
 
 

--- a/src/main/java/com/rymcu/forest/auth/TokenManager.java
+++ b/src/main/java/com/rymcu/forest/auth/TokenManager.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.auth;
 
 /**

--- a/src/main/java/com/rymcu/forest/auth/TokenModel.java
+++ b/src/main/java/com/rymcu/forest/auth/TokenModel.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.auth;
 
 import org.apache.shiro.authc.AuthenticationToken;

--- a/src/main/java/com/rymcu/forest/config/BaseExceptionHandler.java
+++ b/src/main/java/com/rymcu/forest/config/BaseExceptionHandler.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.config;
 
 import com.alibaba.fastjson.support.spring.annotation.FastJsonView;

--- a/src/main/java/com/rymcu/forest/config/MybatisConfigurer.java
+++ b/src/main/java/com/rymcu/forest/config/MybatisConfigurer.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.config;
 
 import com.github.pagehelper.PageInterceptor;

--- a/src/main/java/com/rymcu/forest/config/RabbitMQConfig.java
+++ b/src/main/java/com/rymcu/forest/config/RabbitMQConfig.java
@@ -1,0 +1,117 @@
+package com.rymcu.forest.config;
+
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * RabbitMQ 配置 —— 替代 Spring Event 的消息队列
+ * <p>
+ * 架构：
+ * 1 个 Topic Exchange（forest.events）
+ * 5 个持久化 Queue（按业务域划分）
+ * 7 个 Routing Key（精确路由不同类型的事件）
+ *
+ * @author 麦小文
+ */
+@Configuration
+public class RabbitMQConfig {
+
+    // ==================== 交换机 ====================
+    public static final String FOREST_EXCHANGE = "forest.events";
+
+    // ==================== 队列名 ====================
+    public static final String QUEUE_ARTICLE   = "forest.article";
+    public static final String QUEUE_COMMENT   = "forest.comment";
+    public static final String QUEUE_FOLLOW    = "forest.follow";
+    public static final String QUEUE_PORTFOLIO = "forest.portfolio";
+    public static final String QUEUE_ACCOUNT   = "forest.account";
+
+    // ==================== Routing Key ====================
+    public static final String RK_ARTICLE_POST   = "article.post";
+    public static final String RK_ARTICLE_DELETE = "article.delete";
+    public static final String RK_ARTICLE_STATUS = "article.status";
+    public static final String RK_COMMENT_CREATE = "comment.create";
+    public static final String RK_FOLLOW         = "follow";
+    public static final String RK_PORTFOLIO      = "portfolio";
+    public static final String RK_ACCOUNT_LOGIN  = "account.login";
+
+    // ==================== 交换机 Bean ====================
+    @Bean
+    public TopicExchange forestExchange() {
+        return new TopicExchange(FOREST_EXCHANGE, true, false);
+    }
+
+    // ==================== 队列 Bean ====================
+    @Bean
+    public Queue articleQueue() {
+        return QueueBuilder.durable(QUEUE_ARTICLE).build();
+    }
+
+    @Bean
+    public Queue commentQueue() {
+        return QueueBuilder.durable(QUEUE_COMMENT).build();
+    }
+
+    @Bean
+    public Queue followQueue() {
+        return QueueBuilder.durable(QUEUE_FOLLOW).build();
+    }
+
+    @Bean
+    public Queue portfolioQueue() {
+        return QueueBuilder.durable(QUEUE_PORTFOLIO).build();
+    }
+
+    @Bean
+    public Queue accountQueue() {
+        return QueueBuilder.durable(QUEUE_ACCOUNT).build();
+    }
+
+    // ==================== 绑定 ====================
+    @Bean
+    public Binding articlePostBinding() {
+        return BindingBuilder.bind(articleQueue()).to(forestExchange()).with(RK_ARTICLE_POST);
+    }
+
+    @Bean
+    public Binding articleDeleteBinding() {
+        return BindingBuilder.bind(articleQueue()).to(forestExchange()).with(RK_ARTICLE_DELETE);
+    }
+
+    @Bean
+    public Binding articleStatusBinding() {
+        return BindingBuilder.bind(articleQueue()).to(forestExchange()).with(RK_ARTICLE_STATUS);
+    }
+
+    @Bean
+    public Binding commentBinding() {
+        return BindingBuilder.bind(commentQueue()).to(forestExchange()).with(RK_COMMENT_CREATE);
+    }
+
+    @Bean
+    public Binding followBinding() {
+        return BindingBuilder.bind(followQueue()).to(forestExchange()).with(RK_FOLLOW);
+    }
+
+    @Bean
+    public Binding portfolioBinding() {
+        return BindingBuilder.bind(portfolioQueue()).to(forestExchange()).with(RK_PORTFOLIO);
+    }
+
+    @Bean
+    public Binding accountBinding() {
+        return BindingBuilder.bind(accountQueue()).to(forestExchange()).with(RK_ACCOUNT_LOGIN);
+    }
+
+    // ==================== JSON 序列化 ====================
+    /**
+     * 使用 Jackson 序列化事件对象为 JSON 发送到 RabbitMQ
+     */
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+}

--- a/src/main/java/com/rymcu/forest/config/RabbitMQConfig.java
+++ b/src/main/java/com/rymcu/forest/config/RabbitMQConfig.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.config;
 
 import org.springframework.amqp.core.*;

--- a/src/main/java/com/rymcu/forest/config/RedisKeyExpirationListener.java
+++ b/src/main/java/com/rymcu/forest/config/RedisKeyExpirationListener.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.config;
 
 import com.rymcu.forest.auth.JwtConstants;

--- a/src/main/java/com/rymcu/forest/config/RedisListenerConfig.java
+++ b/src/main/java/com/rymcu/forest/config/RedisListenerConfig.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.config;
 
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/rymcu/forest/config/RedisProperties.java
+++ b/src/main/java/com/rymcu/forest/config/RedisProperties.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/src/main/java/com/rymcu/forest/config/ShiroConfig.java
+++ b/src/main/java/com/rymcu/forest/config/ShiroConfig.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.config;
 
 import com.rymcu.forest.auth.BaseHashedCredentialsMatcher;

--- a/src/main/java/com/rymcu/forest/config/TaskExecutorConfig.java
+++ b/src/main/java/com/rymcu/forest/config/TaskExecutorConfig.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.config;
 
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/rymcu/forest/config/VisitableThreadPoolTaskExecutor.java
+++ b/src/main/java/com/rymcu/forest/config/VisitableThreadPoolTaskExecutor.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.config;
 
 import org.slf4j.Logger;

--- a/src/main/java/com/rymcu/forest/config/WebLogAspect.java
+++ b/src/main/java/com/rymcu/forest/config/WebLogAspect.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.config;
 
 import com.rymcu.forest.util.Utils;

--- a/src/main/java/com/rymcu/forest/config/WebMvcConfigurer.java
+++ b/src/main/java/com/rymcu/forest/config/WebMvcConfigurer.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.config;
 
 

--- a/src/main/java/com/rymcu/forest/config/WebSocketStompConfig.java
+++ b/src/main/java/com/rymcu/forest/config/WebSocketStompConfig.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.config;
 
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/rymcu/forest/event/EventPublisher.java
+++ b/src/main/java/com/rymcu/forest/event/EventPublisher.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.event;
 
 import com.rymcu.forest.config.RabbitMQConfig;

--- a/src/main/java/com/rymcu/forest/event/EventPublisher.java
+++ b/src/main/java/com/rymcu/forest/event/EventPublisher.java
@@ -1,0 +1,64 @@
+package com.rymcu.forest.event;
+
+import com.rymcu.forest.config.RabbitMQConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import javax.annotation.Resource;
+
+/**
+ * 事件发布器 —— 替代 Spring 的 ApplicationEventPublisher
+ * <p>
+ * 核心设计：
+ * <ul>
+ *   <li>如果在事务中 → 注册 TransactionSynchronization，等事务 COMMIT 后再发消息</li>
+ *   <li>如果不在事务中 → 直接发送</li>
+ * </ul>
+ * 完全保持了原来 @TransactionalEventListener(phase = AFTER_COMMIT) 的语义，
+ * 避免"消息发出去了但数据库回滚了"的脏数据问题。
+ *
+ * @author 麦小文
+ */
+@Slf4j
+@Component
+public class EventPublisher {
+
+    @Resource
+    private RabbitTemplate rabbitTemplate;
+
+    /**
+     * 发布事件到 RabbitMQ
+     *
+     * @param routingKey RabbitMQConfig 中定义的 RK_* 常量
+     * @param event      事件对象（会被 Jackson 序列化为 JSON）
+     */
+    public void publish(String routingKey, Object event) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            // 在事务中 → 等事务提交后再发送
+            TransactionSynchronizationManager.registerSynchronization(
+                    new TransactionSynchronization() {
+                        @Override
+                        public void afterCommit() {
+                            doSend(routingKey, event);
+                        }
+                    });
+        } else {
+            // 不在事务中 → 直接发送（如 RedisTokenManager 的登录事件）
+            doSend(routingKey, event);
+        }
+    }
+
+    private void doSend(String routingKey, Object event) {
+        try {
+            rabbitTemplate.convertAndSend(RabbitMQConfig.FOREST_EXCHANGE, routingKey, event);
+            log.info("RabbitMQ 消息已发送: routingKey={}, event={}",
+                    routingKey, event.getClass().getSimpleName());
+        } catch (Exception e) {
+            log.error("RabbitMQ 发送失败: routingKey={}, event={}",
+                    routingKey, event.getClass().getSimpleName(), e);
+        }
+    }
+}

--- a/src/main/java/com/rymcu/forest/handler/AccountHandler.java
+++ b/src/main/java/com/rymcu/forest/handler/AccountHandler.java
@@ -1,10 +1,11 @@
 package com.rymcu.forest.handler;
 
+import com.rymcu.forest.config.RabbitMQConfig;
 import com.rymcu.forest.handler.event.AccountEvent;
 import com.rymcu.forest.mapper.UserMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import javax.annotation.Resource;
 
@@ -22,7 +23,7 @@ public class AccountHandler {
     @Resource
     private UserMapper userMapper;
 
-    @TransactionalEventListener
+    @RabbitListener(queues = RabbitMQConfig.QUEUE_ACCOUNT)
     public void processAccountLastOnlineTimeEvent(AccountEvent accountEvent) {
         userMapper.updateLastOnlineTimeByAccount(accountEvent.getAccount());
     }

--- a/src/main/java/com/rymcu/forest/handler/AccountHandler.java
+++ b/src/main/java/com/rymcu/forest/handler/AccountHandler.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.handler;
 
 import com.rymcu.forest.config.RabbitMQConfig;

--- a/src/main/java/com/rymcu/forest/handler/ArticleHandler.java
+++ b/src/main/java/com/rymcu/forest/handler/ArticleHandler.java
@@ -1,6 +1,6 @@
 package com.rymcu.forest.handler;
 
-import com.alibaba.fastjson.JSON;
+import com.rymcu.forest.config.RabbitMQConfig;
 import com.rymcu.forest.core.constant.NotificationConstant;
 import com.rymcu.forest.handler.event.ArticleDeleteEvent;
 import com.rymcu.forest.handler.event.ArticleEvent;
@@ -8,8 +8,8 @@ import com.rymcu.forest.handler.event.ArticleStatusEvent;
 import com.rymcu.forest.lucene.service.LuceneService;
 import com.rymcu.forest.util.NotificationUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import javax.annotation.Resource;
 import javax.mail.MessagingException;
@@ -26,9 +26,22 @@ public class ArticleHandler {
     @Resource
     private LuceneService luceneService;
 
-    @TransactionalEventListener
-    public void processArticlePostEvent(ArticleEvent articleEvent) {
-        log.info(String.format("执行文章发布相关事件：[%s]", JSON.toJSONString(articleEvent)));
+    /**
+     * 统一的文章事件入口 —— 三种事件共用一个队列，按类型分发
+     */
+    @RabbitListener(queues = RabbitMQConfig.QUEUE_ARTICLE)
+    public void handleArticleEvent(Object event) throws MessagingException {
+        if (event instanceof ArticleEvent) {
+            processArticlePostEvent((ArticleEvent) event);
+        } else if (event instanceof ArticleDeleteEvent) {
+            processArticleDeleteEvent((ArticleDeleteEvent) event);
+        } else if (event instanceof ArticleStatusEvent) {
+            processArticleStatusEvent((ArticleStatusEvent) event);
+        }
+    }
+
+    private void processArticlePostEvent(ArticleEvent articleEvent) {
+        log.info("执行文章发布相关事件：[{}]", articleEvent);
         // 发送系统通知
         if (articleEvent.getNotification()) {
             NotificationUtils.sendAnnouncement(articleEvent.getIdArticle(), NotificationConstant.Article, articleEvent.getArticleTitle());
@@ -54,16 +67,14 @@ public class ArticleHandler {
         log.info("执行完成文章发布相关事件...id={}", articleEvent.getIdArticle());
     }
 
-    @TransactionalEventListener
-    public void processArticleDeleteEvent(ArticleDeleteEvent articleDeleteEvent) {
-        log.info(String.format("执行文章删除相关事件：[%s]", JSON.toJSONString(articleDeleteEvent)));
+    private void processArticleDeleteEvent(ArticleDeleteEvent articleDeleteEvent) {
+        log.info("执行文章删除相关事件：[{}]", articleDeleteEvent);
         luceneService.deleteArticle(articleDeleteEvent.getIdArticle());
         log.info("执行完成文章删除相关事件...id={}", articleDeleteEvent.getIdArticle());
     }
 
-    @TransactionalEventListener
-    public void processArticleStatusEvent(ArticleStatusEvent articleStatusEvent) throws MessagingException {
-        log.info(String.format("执行文章删除相关事件：[%s]", JSON.toJSONString(articleStatusEvent)));
+    private void processArticleStatusEvent(ArticleStatusEvent articleStatusEvent) throws MessagingException {
+        log.info("执行文章状态变更相关事件：[{}]", articleStatusEvent);
         NotificationUtils.saveNotification(articleStatusEvent.getArticleAuthor(), articleStatusEvent.getIdArticle(), NotificationConstant.UpdateArticleStatus, articleStatusEvent.getMessage());
     }
 }

--- a/src/main/java/com/rymcu/forest/handler/ArticleHandler.java
+++ b/src/main/java/com/rymcu/forest/handler/ArticleHandler.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.handler;
 
 import com.rymcu.forest.config.RabbitMQConfig;

--- a/src/main/java/com/rymcu/forest/handler/CommentHandler.java
+++ b/src/main/java/com/rymcu/forest/handler/CommentHandler.java
@@ -1,6 +1,6 @@
 package com.rymcu.forest.handler;
 
-import com.alibaba.fastjson.JSON;
+import com.rymcu.forest.config.RabbitMQConfig;
 import com.rymcu.forest.core.constant.NotificationConstant;
 import com.rymcu.forest.entity.Comment;
 import com.rymcu.forest.handler.event.CommentEvent;
@@ -8,8 +8,8 @@ import com.rymcu.forest.mapper.CommentMapper;
 import com.rymcu.forest.util.Html2TextUtil;
 import com.rymcu.forest.util.NotificationUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import javax.annotation.Resource;
 import javax.mail.MessagingException;
@@ -29,9 +29,9 @@ public class CommentHandler {
     @Resource
     private CommentMapper commentMapper;
 
-    @TransactionalEventListener
+    @RabbitListener(queues = RabbitMQConfig.QUEUE_COMMENT)
     public void processCommentCreatedEvent(CommentEvent commentEvent) throws MessagingException {
-        log.info(String.format("开始执行评论发布事件：[%s]", JSON.toJSONString(commentEvent)));
+        log.info("开始执行评论发布事件：[{}]", commentEvent);
         String commentContent = commentEvent.getContent();
         int length = commentContent.length();
         if (length > MAX_PREVIEW) {

--- a/src/main/java/com/rymcu/forest/handler/CommentHandler.java
+++ b/src/main/java/com/rymcu/forest/handler/CommentHandler.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.handler;
 
 import com.rymcu.forest.config.RabbitMQConfig;

--- a/src/main/java/com/rymcu/forest/handler/FollowHandler.java
+++ b/src/main/java/com/rymcu/forest/handler/FollowHandler.java
@@ -1,12 +1,12 @@
 package com.rymcu.forest.handler;
 
-import com.alibaba.fastjson.JSON;
+import com.rymcu.forest.config.RabbitMQConfig;
 import com.rymcu.forest.core.constant.NotificationConstant;
 import com.rymcu.forest.handler.event.FollowEvent;
 import com.rymcu.forest.util.NotificationUtils;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import javax.mail.MessagingException;
 
@@ -20,9 +20,9 @@ import javax.mail.MessagingException;
 @Slf4j
 @Component
 public class FollowHandler {
-    @TransactionalEventListener
+    @RabbitListener(queues = RabbitMQConfig.QUEUE_FOLLOW)
     public void processFollowEvent(FollowEvent followEvent) throws MessagingException {
-        log.info(String.format("执行关注相关事件: [%s]", JSON.toJSONString(followEvent)));
+        log.info("执行关注相关事件: [{}]", followEvent);
         // 发送系统通知
         NotificationUtils.saveNotification(followEvent.getFollowingId(), followEvent.getIdFollow(), NotificationConstant.Follow, followEvent.getSummary());
         log.info("执行完成关注相关事件...");

--- a/src/main/java/com/rymcu/forest/handler/FollowHandler.java
+++ b/src/main/java/com/rymcu/forest/handler/FollowHandler.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.handler;
 
 import com.rymcu.forest.config.RabbitMQConfig;

--- a/src/main/java/com/rymcu/forest/handler/PortfolioHandler.java
+++ b/src/main/java/com/rymcu/forest/handler/PortfolioHandler.java
@@ -1,12 +1,12 @@
 package com.rymcu.forest.handler;
 
-import com.alibaba.fastjson.JSON;
+import com.rymcu.forest.config.RabbitMQConfig;
 import com.rymcu.forest.handler.event.PortfolioEvent;
 import com.rymcu.forest.lucene.model.PortfolioLucene;
 import com.rymcu.forest.lucene.util.PortfolioIndexUtil;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 /**
  * Created on 2024/12/22 20:39.
@@ -19,9 +19,9 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 public class PortfolioHandler {
 
-    @TransactionalEventListener
+    @RabbitListener(queues = RabbitMQConfig.QUEUE_PORTFOLIO)
     public void processPortfolioEvent(PortfolioEvent portfolioEvent) {
-        log.info("执行作品集发布相关事件：[{}]", JSON.toJSONString(portfolioEvent));
+        log.info("执行作品集发布相关事件：[{}]", portfolioEvent);
         switch (portfolioEvent.getOperateType()) {
             case ADD:
                 log.info("执行完成作品集发布相关事件...id={}", portfolioEvent.getIdPortfolio());

--- a/src/main/java/com/rymcu/forest/handler/PortfolioHandler.java
+++ b/src/main/java/com/rymcu/forest/handler/PortfolioHandler.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.handler;
 
 import com.rymcu.forest.config.RabbitMQConfig;

--- a/src/main/java/com/rymcu/forest/handler/event/AccountEvent.java
+++ b/src/main/java/com/rymcu/forest/handler/event/AccountEvent.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.handler.event;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/rymcu/forest/handler/event/ArticleDeleteEvent.java
+++ b/src/main/java/com/rymcu/forest/handler/event/ArticleDeleteEvent.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.handler.event;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/rymcu/forest/handler/event/ArticleEvent.java
+++ b/src/main/java/com/rymcu/forest/handler/event/ArticleEvent.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.handler.event;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/rymcu/forest/handler/event/ArticleStatusEvent.java
+++ b/src/main/java/com/rymcu/forest/handler/event/ArticleStatusEvent.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.handler.event;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/rymcu/forest/handler/event/CommentEvent.java
+++ b/src/main/java/com/rymcu/forest/handler/event/CommentEvent.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.handler.event;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/rymcu/forest/handler/event/FollowEvent.java
+++ b/src/main/java/com/rymcu/forest/handler/event/FollowEvent.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.handler.event;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/rymcu/forest/handler/event/PortfolioEvent.java
+++ b/src/main/java/com/rymcu/forest/handler/event/PortfolioEvent.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.handler.event;
 
 import com.rymcu.forest.enumerate.OperateType;

--- a/src/main/java/com/rymcu/forest/service/impl/ArticleServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/ArticleServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.constant.NotificationConstant;

--- a/src/main/java/com/rymcu/forest/service/impl/ArticleServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/ArticleServiceImpl.java
@@ -22,7 +22,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.ApplicationEventPublisher;
+import com.rymcu.forest.config.RabbitMQConfig;
+import com.rymcu.forest.event.EventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tk.mybatis.mapper.entity.Condition;
@@ -49,7 +50,7 @@ public class ArticleServiceImpl extends AbstractService<Article> implements Arti
     @Resource
     private NotificationService notificationService;
     @Resource
-    private ApplicationEventPublisher publisher;
+    private EventPublisher eventPublisher;
     @Resource
     private BankAccountService bankAccountService;
 
@@ -59,9 +60,6 @@ public class ArticleServiceImpl extends AbstractService<Article> implements Arti
     private static final int MAX_PREVIEW = 200;
     private static final String DEFAULT_STATUS = "0";
     private static final String DEFAULT_TOPIC_URI = "news";
-
-    @Resource
-    private ApplicationEventPublisher applicationEventPublisher;
 
     @Override
     public List<ArticleDTO> findArticles(ArticleSearchDTO searchDTO) {
@@ -170,7 +168,9 @@ public class ArticleServiceImpl extends AbstractService<Article> implements Arti
         tagService.saveTagArticle(newArticle, articleContentHtml, user.getIdUser());
         if (DEFAULT_STATUS.equals(newArticle.getArticleStatus())) {
             // 文章发布事件
-            publisher.publishEvent(new ArticleEvent(newArticleId, newArticle.getArticleTitle(), isUpdate, notification, user.getNickname(), newArticle.getArticleAuthorId()));
+            eventPublisher.publish(RabbitMQConfig.RK_ARTICLE_POST,
+                    new ArticleEvent(newArticleId, newArticle.getArticleTitle(), isUpdate,
+                            notification, user.getNickname(), newArticle.getArticleAuthorId()));
         }
         return newArticleId;
     }
@@ -185,7 +185,7 @@ public class ArticleServiceImpl extends AbstractService<Article> implements Arti
             // 删除文章
             int result = articleMapper.deleteByPrimaryKey(id);
             if (result > 0) {
-                publisher.publishEvent(new ArticleDeleteEvent(id));
+                eventPublisher.publish(RabbitMQConfig.RK_ARTICLE_DELETE, new ArticleDeleteEvent(id));
             }
             return result;
         } else {
@@ -281,7 +281,8 @@ public class ArticleServiceImpl extends AbstractService<Article> implements Arti
         } else {
             message += "已上架!";
         }
-        applicationEventPublisher.publishEvent(new ArticleStatusEvent(idArticle, article.getArticleAuthorId(), message));
+        eventPublisher.publish(RabbitMQConfig.RK_ARTICLE_STATUS,
+                new ArticleStatusEvent(idArticle, article.getArticleAuthorId(), message));
         return true;
     }
 

--- a/src/main/java/com/rymcu/forest/service/impl/ArticleThumbsUpServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/ArticleThumbsUpServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.exception.BusinessException;

--- a/src/main/java/com/rymcu/forest/service/impl/BankAccountServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/BankAccountServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import cn.hutool.core.date.LocalDateTimeUtil;

--- a/src/main/java/com/rymcu/forest/service/impl/BankServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/BankServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.service.AbstractService;

--- a/src/main/java/com/rymcu/forest/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/CommentServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.exception.ContentNotExistException;

--- a/src/main/java/com/rymcu/forest/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/CommentServiceImpl.java
@@ -13,7 +13,8 @@ import com.rymcu.forest.service.CommentService;
 import com.rymcu.forest.util.Utils;
 import com.rymcu.forest.util.XssUtils;
 import org.apache.commons.lang.StringUtils;
-import org.springframework.context.ApplicationEventPublisher;
+import com.rymcu.forest.config.RabbitMQConfig;
+import com.rymcu.forest.event.EventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +34,7 @@ public class CommentServiceImpl extends AbstractService<Comment> implements Comm
     @Resource
     private ArticleService articleService;
     @Resource
-    private ApplicationEventPublisher applicationEventPublisher;
+    private EventPublisher eventPublisher;
 
     @Override
     public List<CommentDTO> getArticleComments(Integer idArticle) {
@@ -92,7 +93,10 @@ public class CommentServiceImpl extends AbstractService<Comment> implements Comm
 
         String commentContent = comment.getCommentContent();
         if (StringUtils.isNotBlank(commentContent)) {
-            applicationEventPublisher.publishEvent(new CommentEvent(comment.getIdComment(), article.getArticleAuthorId(), comment.getCommentAuthorId(), commentContent, comment.getCommentOriginalCommentId()));
+            eventPublisher.publish(RabbitMQConfig.RK_COMMENT_CREATE,
+                    new CommentEvent(comment.getIdComment(), article.getArticleAuthorId(),
+                            comment.getCommentAuthorId(), commentContent,
+                            comment.getCommentOriginalCommentId()));
         }
         return comment;
     }

--- a/src/main/java/com/rymcu/forest/service/impl/CurrencyRuleServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/CurrencyRuleServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.service.AbstractService;

--- a/src/main/java/com/rymcu/forest/service/impl/DashboardServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/DashboardServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.dto.ArticleDTO;

--- a/src/main/java/com/rymcu/forest/service/impl/FollowServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/FollowServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.service.AbstractService;

--- a/src/main/java/com/rymcu/forest/service/impl/FollowServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/FollowServiceImpl.java
@@ -6,7 +6,8 @@ import com.rymcu.forest.entity.Follow;
 import com.rymcu.forest.handler.event.FollowEvent;
 import com.rymcu.forest.mapper.FollowMapper;
 import com.rymcu.forest.service.FollowService;
-import org.springframework.context.ApplicationEventPublisher;
+import com.rymcu.forest.config.RabbitMQConfig;
+import com.rymcu.forest.event.EventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,7 +23,7 @@ public class FollowServiceImpl extends AbstractService<Follow> implements Follow
     @Resource
     private FollowMapper followMapper;
     @Resource
-    private ApplicationEventPublisher applicationEventPublisher;
+    private EventPublisher eventPublisher;
 
     @Override
     public Boolean isFollow(Integer followingId, String followingType, Long idUser) {
@@ -34,7 +35,9 @@ public class FollowServiceImpl extends AbstractService<Follow> implements Follow
     public Boolean follow(Follow follow, String nickname) {
         int result = followMapper.insertSelective(follow);
         if (result > 0) {
-            applicationEventPublisher.publishEvent(new FollowEvent(follow.getFollowingId(), follow.getFollowerId(), nickname + " 关注了你!"));
+            eventPublisher.publish(RabbitMQConfig.RK_FOLLOW,
+                    new FollowEvent(follow.getFollowingId(), follow.getFollowerId(),
+                            nickname + " 关注了你!"));
         }
         return result > 0;
     }

--- a/src/main/java/com/rymcu/forest/service/impl/ForestFileServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/ForestFileServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.service.AbstractService;

--- a/src/main/java/com/rymcu/forest/service/impl/JavaMailServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/JavaMailServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.constant.NotificationConstant;

--- a/src/main/java/com/rymcu/forest/service/impl/LoginRecordServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/LoginRecordServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import cn.hutool.http.useragent.UserAgent;

--- a/src/main/java/com/rymcu/forest/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/NotificationServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.service.AbstractService;

--- a/src/main/java/com/rymcu/forest/service/impl/OpenDataServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/OpenDataServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.dto.admin.Dashboard;

--- a/src/main/java/com/rymcu/forest/service/impl/PermissionServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/PermissionServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.service.AbstractService;

--- a/src/main/java/com/rymcu/forest/service/impl/PortfolioServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/PortfolioServiceImpl.java
@@ -19,7 +19,8 @@ import com.rymcu.forest.service.UserService;
 import com.rymcu.forest.util.XssUtils;
 import com.rymcu.forest.web.api.common.UploadController;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.context.ApplicationEventPublisher;
+import com.rymcu.forest.config.RabbitMQConfig;
+import com.rymcu.forest.event.EventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -40,7 +41,7 @@ public class PortfolioServiceImpl extends AbstractService<Portfolio> implements 
     @Resource
     private ArticleService articleService;
     @Resource
-    private ApplicationEventPublisher applicationEventPublisher;
+    private EventPublisher eventPublisher;
 
     @Override
     public List<PortfolioDTO> findUserPortfoliosByUser(UserDTO userDTO) {
@@ -92,7 +93,10 @@ public class PortfolioServiceImpl extends AbstractService<Portfolio> implements 
             portfolio.setPortfolioDescriptionHtml(XssUtils.filterHtmlCode(portfolio.getPortfolioDescription()));
             portfolioMapper.insertSelective(portfolio);
         }
-        applicationEventPublisher.publishEvent(new PortfolioEvent(portfolio.getIdPortfolio(), portfolio.getPortfolioTitle(), portfolio.getPortfolioDescription(), isUpdate ? OperateType.UPDATE : OperateType.ADD));
+        eventPublisher.publish(RabbitMQConfig.RK_PORTFOLIO,
+                new PortfolioEvent(portfolio.getIdPortfolio(), portfolio.getPortfolioTitle(),
+                        portfolio.getPortfolioDescription(),
+                        isUpdate ? OperateType.UPDATE : OperateType.ADD));
         return portfolio;
     }
 
@@ -170,7 +174,8 @@ public class PortfolioServiceImpl extends AbstractService<Portfolio> implements 
             if (result.equals(0)) {
                 throw new BusinessException("操作失败！");
             }
-            applicationEventPublisher.publishEvent(new PortfolioEvent(idPortfolio, null, null, OperateType.DELETE));
+            eventPublisher.publish(RabbitMQConfig.RK_PORTFOLIO,
+                    new PortfolioEvent(idPortfolio, null, null, OperateType.DELETE));
             return true;
         }
     }

--- a/src/main/java/com/rymcu/forest/service/impl/PortfolioServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/PortfolioServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.github.pagehelper.PageHelper;

--- a/src/main/java/com/rymcu/forest/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/ProductServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.service.AbstractService;

--- a/src/main/java/com/rymcu/forest/service/impl/RoleServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/RoleServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.exception.ServiceException;

--- a/src/main/java/com/rymcu/forest/service/impl/SpecialDayServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/SpecialDayServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.service.AbstractService;

--- a/src/main/java/com/rymcu/forest/service/impl/SponsorServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/SponsorServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 

--- a/src/main/java/com/rymcu/forest/service/impl/TagServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/TagServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.alibaba.fastjson.JSON;

--- a/src/main/java/com/rymcu/forest/service/impl/TopicServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/TopicServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.exception.BusinessException;

--- a/src/main/java/com/rymcu/forest/service/impl/TransactionRecordServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/TransactionRecordServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.exception.TransactionException;

--- a/src/main/java/com/rymcu/forest/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/UserServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.github.f4b6a3.ulid.UlidCreator;

--- a/src/main/java/com/rymcu/forest/service/impl/VisitServiceImpl.java
+++ b/src/main/java/com/rymcu/forest/service/impl/VisitServiceImpl.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service.impl;
 
 import com.rymcu.forest.core.service.AbstractService;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,6 +8,20 @@ spring:
     servlet:
       content-type: text/html
     cache: false
+  rabbitmq:
+    host: 127.0.0.1
+    port: 5672
+    username: guest
+    password: guest
+    virtual-host: /
+    listener:
+      simple:
+        retry:
+          enabled: true
+          max-attempts: 3
+          initial-interval: 3000ms
+    publisher-confirm-type: correlated
+    publisher-returns: true
   redis:
     host: 192.168.31.200
     port: 6379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,20 @@ spring:
     port: 465
     username: # 邮箱
     password: # 密码
+  rabbitmq:
+    host: 127.0.0.1
+    port: 5672
+    username: guest
+    password: guest
+    virtual-host: /
+    listener:
+      simple:
+        retry:
+          enabled: true
+          max-attempts: 3
+          initial-interval: 3000ms
+    publisher-confirm-type: correlated
+    publisher-returns: true
   application:
     name: forest
 wx:

--- a/src/test/java/com/rymcu/forest/ForestApplicationTests.java
+++ b/src/test/java/com/rymcu/forest/ForestApplicationTests.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/rymcu/forest/base/BaseServiceTest.java
+++ b/src/test/java/com/rymcu/forest/base/BaseServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.base;
 
 import org.junit.jupiter.api.MethodOrderer;

--- a/src/test/java/com/rymcu/forest/service/ArticleServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/ArticleServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import cn.hutool.core.collection.CollectionUtil;

--- a/src/test/java/com/rymcu/forest/service/ArticleThumbsUpServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/ArticleThumbsUpServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/BankAccountServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/BankAccountServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/BankServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/BankServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/CommentServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/CommentServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/CurrencyRuleServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/CurrencyRuleServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/DashboardServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/DashboardServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/FollowServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/FollowServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/ForestFileServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/ForestFileServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/JavaMailServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/JavaMailServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/LoginRecordServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/LoginRecordServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/NotificationServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/NotificationServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/OpenDataServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/OpenDataServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/PermissionServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/PermissionServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/PortfolioServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/PortfolioServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.github.pagehelper.PageInfo;

--- a/src/test/java/com/rymcu/forest/service/ProductServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/ProductServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/RoleServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/RoleServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/SpecialDayServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/SpecialDayServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/SponsorServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/SponsorServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/TagServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/TagServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/TopicServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/TopicServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/TransactionRecordServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/TransactionRecordServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/UserServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/UserServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;

--- a/src/test/java/com/rymcu/forest/service/VisitServiceTest.java
+++ b/src/test/java/com/rymcu/forest/service/VisitServiceTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2020 RYMCU (https://rymcu.com)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
 package com.rymcu.forest.service;
 
 import com.rymcu.forest.base.BaseServiceTest;


### PR DESCRIPTION
 ## 🐰 将 Spring Event 替换为 RabbitMQ 消息队列

  ### 动机
  当前项目使用 Spring Event + @TransactionalEventListener 处理异步任务（Lucene 索引更新、通知推送等），存在以下问题：
  - 紧耦合：发布者和消费者在同一 JVM 进程内
  - 不可重试：消费失败直接丢失
  - 不可监控：无法查看消息积压情况
  - 不可扩展：消费者无法独立部署

  ### 改动内容
  - ✅ 添加 `spring-boot-starter-amqp` 依赖
  - ✅ 新增 `RabbitMQConfig`：1 个 Exchange + 5 个 Queue + 7 个 Binding
  - ✅ 新增 `EventPublisher`：TransactionSynchronization.afterCommit() 保证事务后投递
  - ✅ 替换 8 处 ApplicationEventPublisher.publishEvent() → EventPublisher.publish()
  - ✅ 替换 5 个 Handler 的 @TransactionalEventListener → @RabbitListener
  - ✅ 事件 POJO 类无需修改，业务逻辑零改动
  - ✅ 支持消息重试（max-attempts=3）

  ### 架构对比
  改造前：Service → ApplicationEventPublisher → @TransactionalEventListener (同步/同进程)
  改造后：Service → RabbitMQ Exchange → Queue → @RabbitListener (异步/解耦/可重试)

  ### 测试方法
  1. 启动 RabbitMQ：docker run -d -p 5672:5672 rabbitmq:3-management
  2. 发布文章 → 检查 Lucene 索引更新
  3. 发表评论 → 检查通知推送
  4. 关注用户 → 检查通知
  5. 登录 → 检查最后在线时间更新
